### PR TITLE
Fix for "Compile error: unknown type name 'time_t'"

### DIFF
--- a/examples/indicator_basis/main/model/indicator_time.h
+++ b/examples/indicator_basis/main/model/indicator_time.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "view_data.h"
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/examples/indicator_basis/main/view_data.h
+++ b/examples/indicator_basis/main/view_data.h
@@ -2,6 +2,7 @@
 #define VIEW_DATA_H
 
 #include "config.h"
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Seems like a few of the demos are broken. This is a fix for the indicator_basis one