### PR TITLE
indicator_ha: fix time_t compile error

### DIFF
--- a/examples/indicator_ha/main/view_data.h
+++ b/examples/indicator_ha/main/view_data.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+typedef long long int time_t;
+
 enum start_screen{
     SCREEN_SENSECAP_LOG, //todo
     SCREEN_WIFI_CONFIG,


### PR DESCRIPTION
Fix compile error:

In file included from SenseCAP_Indicator_ESP32/examples/indicator_ha/main/model/indicator_city.h:5,
                 from SenseCAP_Indicator_ESP32/examples/indicator_ha/main/model/indicator_city.c:1:
SenseCAP_Indicator_ESP32/examples/indicator_ha/main/view_data.h:72:5: error: unknown type name 'time_t'
   72 |     time_t  time;       // use when auto_update is true
      |     ^~~~~~
SenseCAP_Indicator_ESP32/examples/indicator_ha/main/view_data.h:84:5: error: unknown type name 'time_t'
   84 |     time_t  timestamp;
      |     ^~~~~~
SenseCAP_Indicator_ESP32/examples/indicator_ha/main/view_data.h:92:5: error: unknown type name 'time_t'
   92 |     time_t  timestamp;
      |     ^~~~~~
ninja: build stopped: subcommand failed.
ninja failed with exit code 1, output of the command is in the SenseCAP_Indicator_ESP32/examples/indicator_ha/build/log/idf_py_stderr_output_329923 and SenseCAP_Indicator_ESP32/examples/indicator_ha/build/log/idf_py_stdout_output_329923
